### PR TITLE
Upgrade some cpp.vm references to sys.thread

### DIFF
--- a/debugger/DebuggerThread.hx
+++ b/debugger/DebuggerThread.hx
@@ -23,9 +23,9 @@ import debugger.IController;
 import haxe.CallStack;
 
 #if cpp
-import cpp.vm.Deque;
-import cpp.vm.Mutex;
-import cpp.vm.Thread;
+import sys.thread.Deque;
+import sys.thread.Mutex;
+import sys.thread.Thread;
 #elseif neko
 import neko.vm.Deque;
 import neko.vm.Mutex;

--- a/debugger/VSCodeRemote.hx
+++ b/debugger/VSCodeRemote.hx
@@ -26,9 +26,9 @@ import debugger.HaxeProtocol;
 import debugger.IController;
 
 #if cpp
-import cpp.vm.Thread;
-import cpp.vm.Mutex;
-import cpp.vm.Debugger;
+import sys.thread.Thread;
+import sys.thread.Mutex;
+import sys.thread.Debugger;
 #else
 #error "HaxeRemote supported only for cpp targets"
 #end


### PR DESCRIPTION
Hopefully fixes the following warnings in the compiler log:
```
[exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/VSCodeRemote.hx:225: characters 32-38 : Warning : This typedef is deprecated in favor of sys.thread.Thread
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:1203: characters 31-36 : Warning : This typedef is deprecated in favor of sys.thread.Mutex
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:1216: characters 38-43 : Warning : This typedef is deprecated in favor of sys.thread.Mutex
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:1219: characters 38-49 : Warning : This typedef is deprecated in favor of sys.thread.Deque<cpp.vm.Deque.T>
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/VSCodeRemote.hx:177: characters 28-34 : Warning : Usage of this typedef is deprecated
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/VSCodeRemote.hx:152: characters 27-33 : Warning : Usage of this typedef is deprecated
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:1216: characters 50-55 : Warning : This typedef is deprecated in favor of sys.thread.Mutex
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:81: characters 27-32 : Warning : This typedef is deprecated in favor of sys.thread.Mutex
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:99: characters 9-15 : Warning : Usage of this typedef is deprecated
     [exec] C:\Workspaces\dyost_main\Local\caller/../haxelibs/hxcpp-debugger/git/debugger/DebuggerThread.hx:1219: characters 56-67 : Warning : This typedef is deprecated in favor of sys.thread.Deque<cpp.vm.Deque.T>
```

Not sure how to test or build locally, but made these changes per recommendation by @waneck 